### PR TITLE
Add the ability to provide remote destination filename or keep relative path in destination filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ In this Example, the baudrate is changed to 19.2k and COM3 is selected as defaul
     "baudrate": "19200",
     "port": "COM3",
     "compile": true,
-    "optimize": true
+    "optimize": true,
+    "keeppath": true
 }
 ```
  
@@ -149,6 +150,7 @@ All configuration options are **optional**
 * **port** (string) - the comport to use
 * **compile** (boolean) - compile lua files after upload
 * **optimize** (boolean) - optimize files before uploading
+* **keeppath** (boolean) - keep the relative file path in the destination filename (i.e: static/test.html will be named static/test.html)
  
  
 ### Notes ###
@@ -211,7 +213,9 @@ The most important task of this tool: upload local files to the module.
 **Options**
 
 * `--optimize` | Remove Comments, Whitespaces and empty lines from the file before upload
-* `--compile`  | Compiles the uploaded .lua file into executable bytecode and removes the source .lua file (performance) 
+* `--compile`  | Compiles the uploaded .lua file into executable bytecode and removes the source .lua file (performance)
+* `--keeppath` | Keeps the relative file path in the destination filename (i.e: static/test.html will be named static/test.html)
+* `--remotename` | Set the destination file name
 
 **Example 1**
 
@@ -243,6 +247,27 @@ Upload a text file.
 ```shell
 $ nodemcu-tool upload HelloWorld.txt
 ```
+
+**Example 4**
+
+Upload a static file and keep its relative path as remote name.
+
+```shell
+$ nodemcu-tool upload static/hello.html --keeppath
+```
+
+The remote file name will be "static/hello.html"
+
+**Example 5**
+
+Upload a text file and change its remote name.
+
+```shell
+$ nodemcu-tool upload HelloWorld.txt --remotename MyFile.txt
+```
+
+The remote file name will be "MyFile.txt"
+
 
 ### Download Files ###
 To backup files or fetch recorded data, NodeMCU-Tool allows you to download these files from NodeMCU using the `download` command.

--- a/bin/nodemcu-tool.js
+++ b/bin/nodemcu-tool.js
@@ -34,7 +34,7 @@ var defaults = (function(){
         port: '/dev/ttyUSB0',
         optimize: false,
         compile: false,
-        keepPath: false
+        keeppath: false
     };
 
     try{
@@ -50,7 +50,7 @@ var defaults = (function(){
             config.port = d.port || config.port;
             config.optimize = (d.optimize && d.optimize === true);
             config.compile = (d.compile && d.compile === true);
-            config.keepPath = (d.keepPath && d.keepPath === true);
+            config.keeppath = (d.keeppath && d.keeppath === true);
             console.log(_colors.cyan('[NodeMCU-Tool]'), 'Project based configuration loaded');
         }
     }catch (err){
@@ -96,7 +96,7 @@ _cli
     // compile files after upload
     .option('-c, --compile', 'Compile LUA file to bytecode (.lc) and remove the original file after upload', false)
     // keep-path
-    .option('-k, --keeppath', 'Keep the original file path in the destination filename (i.e: static/test.html will be named static/test.html', false)
+    .option('-k, --keeppath', 'Keep a relative file path in the destination filename (i.e: static/test.html will be named static/test.html)', false)
     .option('-n, --remotename <remotename>', 'Set destination file name. Default is same as original', false)
 
     .action(function(localFile, options){
@@ -114,7 +114,7 @@ _cli
             options.optimize = defaults.optimize;
         }
         if (!options.keeppath){
-          options.keeppath = defaults.keepPath;
+          options.keeppath = defaults.keeppath;
         }
 
         _nodemcutool.upload(_cli.port, _cli.baud, localFile, options, function(current, total){

--- a/bin/nodemcu-tool.js
+++ b/bin/nodemcu-tool.js
@@ -33,7 +33,8 @@ var defaults = (function(){
         baudrate: '9600',
         port: '/dev/ttyUSB0',
         optimize: false,
-        compile: false
+        compile: false,
+        keepPath: false
     };
 
     try{
@@ -49,7 +50,7 @@ var defaults = (function(){
             config.port = d.port || config.port;
             config.optimize = (d.optimize && d.optimize === true);
             config.compile = (d.compile && d.compile === true);
-
+            config.keepPath = (d.keepPath && d.keepPath === true);
             console.log(_colors.cyan('[NodeMCU-Tool]'), 'Project based configuration loaded');
         }
     }catch (err){
@@ -94,6 +95,9 @@ _cli
 
     // compile files after upload
     .option('-c, --compile', 'Compile LUA file to bytecode (.lc) and remove the original file after upload', false)
+    // keep-path
+    .option('-k, --keeppath', 'Keep the original file path in the destination filename (i.e: static/test.html will be named static/test.html', false)
+    .option('-n, --remotename <remotename>', 'Set destination file name. Default is same as original', false)
 
     .action(function(localFile, options){
         // initialize a new progress bar
@@ -108,6 +112,9 @@ _cli
         }
         if (!options.optimize){
             options.optimize = defaults.optimize;
+        }
+        if (!options.keeppath){
+          options.keeppath = defaults.keepPath;
         }
 
         _nodemcutool.upload(_cli.port, _cli.baud, localFile, options, function(current, total){

--- a/lib/NodeMCU-Tool.js
+++ b/lib/NodeMCU-Tool.js
@@ -1,7 +1,7 @@
 var _fs = require('fs');
 var _nodeMcuConnector = require('./NodeMcuConnector');
 var _serialTerminal = require('./SerialTerminal');
-
+var _path = require('path');
 // global default error handler
 var errorHandler = function(source, error){
     console.error('[' + source + '] ' + error);
@@ -108,7 +108,7 @@ var Tool = {
 
             // filename defaults to original filename minus path.
             // this behaviour can be overridden by --keeppath and --remotename options
-            var remoteFile = options.destname ? options.destname : options.keeppath ? filename : _path.basename(filename);
+            var remoteFile = options.remotename ? options.remotename : options.keeppath ? filename : _path.basename(localFile);
             
             connector.upload(localFile, remoteFile, options,
 

--- a/lib/NodeMCU-Tool.js
+++ b/lib/NodeMCU-Tool.js
@@ -108,7 +108,7 @@ var Tool = {
 
             // filename defaults to original filename minus path.
             // this behaviour can be overridden by --keeppath and --remotename options
-            var remoteFile = options.remotename ? options.remotename : options.keeppath ? filename : _path.basename(localFile);
+            var remoteFile = options.remotename ? options.remotename : options.keeppath ? localFile : _path.basename(localFile);
             
             connector.upload(localFile, remoteFile, options,
 

--- a/lib/NodeMCU-Tool.js
+++ b/lib/NodeMCU-Tool.js
@@ -106,7 +106,11 @@ var Tool = {
             logStatus('NodeMCU', response);
             logStatus('NodeMCU-Tool', 'Uploading "' + localFile + '" ...');
 
-            connector.upload(localFile, options.optimize,
+            // filename defaults to original filename minus path.
+            // this behaviour can be overridden by --keeppath and --remotename options
+            var remoteFile = options.destname ? options.destname : options.keeppath ? filename : _path.basename(filename);
+            
+            connector.upload(localFile, remoteFile, options,
 
                 // onComplete
                 function(err){
@@ -116,7 +120,7 @@ var Tool = {
                     if (options.compile){
                         logStatus('NodeMCU', 'compiling lua file..');
 
-                        connector.compile(localFile, function(error){
+                        connector.compile(remoteFile, function(error){
                             // success ? empty line will return (null)
                             if (error){
                                 connector.disconnect();
@@ -124,8 +128,8 @@ var Tool = {
                             }else{
                                 logStatus('NodeMCU', 'Success');
 
-                                // drop oiginal lua file
-                                connector.removeFile(localFile, function(){
+                                // drop original lua file
+                                connector.removeFile(remoteFile, function(){
                                     connector.disconnect();
                                     logStatus('NodeMCU', 'Original LUA file removed');
                                 });
@@ -137,7 +141,6 @@ var Tool = {
                         connector.disconnect();
                     }
                 },
-
                 // on progress handler
                 onProgess || function(){}
             );

--- a/lib/NodeMcuConnector.js
+++ b/lib/NodeMcuConnector.js
@@ -171,13 +171,13 @@ NodeMcuConnector.prototype.fetchDeviceInfo = function(cb){
 // upload a local file to NodeMCU
 /**
  * Upload a local file to NodeMCU
- * @param localname the original filename
- * @param remotename the destination name
+ * @param localName the original filename
+ * @param remoteName the destination name
  * @param options
  * @param completeCb
  * @param progressCb
  */
-NodeMcuConnector.prototype.upload = function(localname, remotename, options, completeCb, progressCb){
+NodeMcuConnector.prototype.upload = function(localName, remoteName, options, completeCb, progressCb){
   
     // check connect flag
     if (!this.isConnected){
@@ -186,10 +186,10 @@ NodeMcuConnector.prototype.upload = function(localname, remotename, options, com
     }
 
     // get file content
-    var rawContent = _fs.readFileSync(localname);
+    var rawContent = _fs.readFileSync(localName);
 
     // remove lua comments and empty lines ?
-    if (options.optimize && _path.extname(localname).toLowerCase() == '.lua'){
+    if (options.optimize && _path.extname(localName).toLowerCase() == '.lua'){
         // apply optimizations
         var t = rawContent.toString('utf-8')
             .replace(/--.*$/gim, '')
@@ -211,11 +211,11 @@ NodeMcuConnector.prototype.upload = function(localname, remotename, options, com
     var chunks = content.match(/.{1,232}/g);
 
     // drop file (override)
-    this.device.executeCommand(luaPrepare(lua_commands.fileRemove, [remoteFilename]), function(err, echo, response){
+    this.device.executeCommand(luaPrepare(lua_commands.fileRemove, [remoteName]), function(err, echo, response){
 
         // successful removed ?
         if (err){
-            completeCb('Cannot remove file "' + remoteFilename + '" - ' + err);
+            completeCb('Cannot remove file "' + remoteName + '" - ' + err);
             return;
         }
 
@@ -228,10 +228,10 @@ NodeMcuConnector.prototype.upload = function(localname, remotename, options, com
             }
 
             // open remote file for write
-            this.device.executeCommand(luaPrepare(lua_commands.fileOpen, [remoteFilename, 'w+']), function(err, echo, response){
+            this.device.executeCommand(luaPrepare(lua_commands.fileOpen, [remoteName, 'w+']), function(err, echo, response){
                 // successful opened ?
                 if (err || response != 'true'){
-                    completeCb('Cannot open remote file "' + remoteFilename + '" for write - ' + err);
+                    completeCb('Cannot open remote file "' + remoteName + '" for write - ' + err);
                     return;
                 }
 
@@ -354,18 +354,15 @@ NodeMcuConnector.prototype.fsinfo = function(cb){
 };
 
 // delete a file from remote filesystem
-NodeMcuConnector.prototype.removeFile = function(filename, cb){
+NodeMcuConnector.prototype.removeFile = function(remoteName, cb){
     // check connect flag
     if (!this.isConnected){
         cb('Cannot remove remote file - device offline', null);
         return;
     }
 
-    // drop path from filename
-    filename =_path.basename(filename);
-
     // get file system info (size)
-    this.device.executeCommand(luaPrepare(lua_commands.fileRemove, [filename]), function(err, echo, response){
+    this.device.executeCommand(luaPrepare(lua_commands.fileRemove, [remoteName]), function(err, echo, response){
         if (err){
             cb('IO Error - ' + err, null);
         }else{
@@ -411,18 +408,15 @@ NodeMcuConnector.prototype.compile = function(remoteName, cb){
 };
 
 // execute a remote file
-NodeMcuConnector.prototype.run = function(filename, cb){
+NodeMcuConnector.prototype.run = function(remoteName, cb){
     // check connect flag
     if (!this.isConnected){
         cb('Cannot execute remote file - device offline', null);
         return;
     }
 
-    // drop path from filename
-    filename =_path.basename(filename);
-
     // run the lua compiler/interpreter to cache the file as bytecode
-    this.device.executeCommand(luaPrepare(lua_commands.run, [filename]), function(err, echo, response){
+    this.device.executeCommand(luaPrepare(lua_commands.run, [remoteName]), function(err, echo, response){
         if (err){
             cb('IO Error - ' + err, null);
         }else{
@@ -446,15 +440,12 @@ NodeMcuConnector.prototype.executeCommand = function(cmd, cb){
 
 
 // download a file from NodeMCU
-NodeMcuConnector.prototype.download = function(filename, cb){
+NodeMcuConnector.prototype.download = function(remoteName, cb){
     // check connect flag
     if (!this.isConnected){
         cb('Cannot upload file - device offline', null);
         return;
     }
-
-    // drop path from filename...
-    var remoteFilename =_path.basename(filename);
 
     // transfer helper function to encode hex data
     this.device.executeCommand(lua_commands.hexReadHelper, function(err, echo, response) {

--- a/lib/NodeMcuConnector.js
+++ b/lib/NodeMcuConnector.js
@@ -18,7 +18,7 @@ var lua_commands = {
     fsFormat: 'file.format()',
 
     // compile a remote file
-    compile: 'node.comgpile("?")',
+    compile: 'node.compile("?")',
 
     // run a file
     run: 'dofile("?")',

--- a/lib/NodeMcuConnector.js
+++ b/lib/NodeMcuConnector.js
@@ -18,7 +18,7 @@ var lua_commands = {
     fsFormat: 'file.format()',
 
     // compile a remote file
-    compile: 'node.compile("?")',
+    compile: 'node.comgpile("?")',
 
     // run a file
     run: 'dofile("?")',
@@ -169,21 +169,27 @@ NodeMcuConnector.prototype.fetchDeviceInfo = function(cb){
 };
 
 // upload a local file to NodeMCU
-NodeMcuConnector.prototype.upload = function(filename, optimize, completeCb, progressCb){
+/**
+ * Upload a local file to NodeMCU
+ * @param localname the original filename
+ * @param remotename the destination name
+ * @param options
+ * @param completeCb
+ * @param progressCb
+ */
+NodeMcuConnector.prototype.upload = function(localname, remotename, options, completeCb, progressCb){
+  
     // check connect flag
     if (!this.isConnected){
         completeCb('Cannot upload file - device offline', null);
         return;
     }
 
-    // drop path from filename
-    var remoteFilename =_path.basename(filename);
-
     // get file content
-    var rawContent = _fs.readFileSync(filename);
+    var rawContent = _fs.readFileSync(localname);
 
     // remove lua comments and empty lines ?
-    if (optimize && _path.extname(filename).toLowerCase() == '.lua'){
+    if (options.optimize && _path.extname(localname).toLowerCase() == '.lua'){
         // apply optimizations
         var t = rawContent.toString('utf-8')
             .replace(/--.*$/gim, '')
@@ -387,18 +393,15 @@ NodeMcuConnector.prototype.format = function(cb){
 };
 
 // compile a remote file
-NodeMcuConnector.prototype.compile = function(filename, cb){
+NodeMcuConnector.prototype.compile = function(remoteName, cb){
     // check connect flag
     if (!this.isConnected){
         cb('Cannot compile remote file - device offline', null);
         return;
     }
 
-    // drop path from filename
-    filename =_path.basename(filename);
-
     // run the lua compiler/interpreter to cache the file as bytecode
-    this.device.executeCommand(luaPrepare(lua_commands.compile, [filename]), function(err, echo, response){
+    this.device.executeCommand(luaPrepare(lua_commands.compile, [remoteName]), function(err, echo, response){
         if (err){
             cb('IO Error - ' + err, null);
         }else{


### PR DESCRIPTION
First, let me thank you for this awesome tool that you have provided.
I use it a lot and I think it is a great replacement for the python tool.

For many use-cases (especially webservers and static files), it is important for an upload script to keep the paths in the filenames.

As you know, NodeMCU's filesystem is key/value based and it is possible to have slashes in a filename.

The default behaviour for this was to strip the path, and only keep the filename.

I propose this PR which gives the user two more options in the CLI: --keeppath and --remotename.

N.B: This changes the upload function signature a little. If you have important concerts about backward compatibility, thanks for letting me know, and I will rearrange the code to trick it.
