### PR TITLE
Fix crashing when trying to upload a folder

### DIFF
--- a/lib/NodeMCU-Tool.js
+++ b/lib/NodeMCU-Tool.js
@@ -142,11 +142,17 @@ Tool.upload = function(localFiles, options, onProgess){
         // get file stats
         try{
             var fileInfo = _fs.statSync(localFile);
-
         // local file available
-        }catch (err){
+        } catch (err){
             _logger.error('Local file not found "' + localFile + '" skipping...');
             onComplete();
+            return;
+        }
+        
+        // check if file is directory
+        if (fileInfo.isDirectory()) {
+            _mculogger.error('Path "' + localFile + '" is a directory.');
+            onComplete(1);
             return;
         }
 
@@ -236,12 +242,12 @@ Tool.upload = function(localFiles, options, onProgess){
             var remoteFile = options.remotename ? options.remotename : (options.keeppath ? localFile : _path.basename(localFile));
 
             // start single file upload
-            uploadFile(connector, localFile, remoteFile, function(){
+            uploadFile(connector, localFile, remoteFile, function(err){
                 // close connection
                 connector.disconnect();
 
                 // log message
-                _logger.log('File Transfer complete!');
+                if (!err) _logger.log('File Transfer complete!');
             });
 
         // bulk upload ?

--- a/lib/NodeMCU-Tool.js
+++ b/lib/NodeMCU-Tool.js
@@ -152,7 +152,7 @@ Tool.upload = function(localFiles, options, onProgess){
         // check if file is directory
         if (fileInfo.isDirectory()) {
             _mculogger.error('Path "' + localFile + '" is a directory.');
-            onComplete(1);
+            onComplete();
             return;
         }
 
@@ -242,12 +242,12 @@ Tool.upload = function(localFiles, options, onProgess){
             var remoteFile = options.remotename ? options.remotename : (options.keeppath ? localFile : _path.basename(localFile));
 
             // start single file upload
-            uploadFile(connector, localFile, remoteFile, function(err){
+            uploadFile(connector, localFile, remoteFile, function(){
                 // close connection
                 connector.disconnect();
 
                 // log message
-                if (!err) _logger.log('File Transfer complete!');
+                _logger.log('File Transfer complete!');
             });
 
         // bulk upload ?


### PR DESCRIPTION
Currently, if you try to upload a directory the tool crashes with `Error: EISDIR: illegal operation on a directory, read` and a stack trace. I added an error message to handle this case.

Maybe adding a 'recursive' flag to upload whole folders would be interesting? I could work on that :smile:

Thanks for writing this tool by the way, very useful.