### PR TITLE
Add fastupload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ The most important task of this tool: upload local files to the module.
 * `--compile`  | Compiles the uploaded .lua file into executable bytecode and removes the source .lua file (performance)
 * `--keeppath` | Keeps the relative file path in the destination filename (i.e: static/test.html will be named static/test.html)
 * `--remotename` | Set the destination file name
+* `--fastupload` | Use base64 encoding for file upload. **IMPORTANT** : The _NodeMCU_ module "**encode**" must be present on the firmeware (which is not the case by default).
 
 **Example 1**
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ The most important task of this tool: upload local files to the module.
 * `--compile`  | Compiles the uploaded .lua file into executable bytecode and removes the source .lua file (performance)
 * `--keeppath` | Keeps the relative file path in the destination filename (i.e: static/test.html will be named static/test.html)
 * `--remotename` | Set the destination file name
-* `--fastupload` | Boost the upload speed by using base64 encoding. **IMPORTANT** : The _NodeMCU_ module "**encode**" must be present on the firmeware (which is not the case by default).
+* `--fastupload` | Boost the upload speed by using base64 encoding. **IMPORTANT**: The _NodeMCU_ module "**encode**" must be present on the firmware (which is not the case by default).
 
 **Example 1**
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ The most important task of this tool: upload local files to the module.
 * `--compile`  | Compiles the uploaded .lua file into executable bytecode and removes the source .lua file (performance)
 * `--keeppath` | Keeps the relative file path in the destination filename (i.e: static/test.html will be named static/test.html)
 * `--remotename` | Set the destination file name
-* `--fastupload` | Use base64 encoding for file upload. **IMPORTANT** : The _NodeMCU_ module "**encode**" must be present on the firmeware (which is not the case by default).
+* `--fastupload` | Boost the upload speed by using base64 encoding. **IMPORTANT** : The _NodeMCU_ module "**encode**" must be present on the firmeware (which is not the case by default).
 
 **Example 1**
 

--- a/bin/nodemcu-tool.js
+++ b/bin/nodemcu-tool.js
@@ -77,7 +77,7 @@ function cliPrepare(options){
         json:       options.json        || false,
         raw:        options.raw         || false,
         softreset:  options.softreset   || false,
-        fastupload: options.fastupload    || false
+        fastupload: options.fastupload  || false
     };
 
     // project based configuration
@@ -95,6 +95,7 @@ function cliPrepare(options){
             defaultConfig.optimize = (d.optimize && d.optimize === true);
             defaultConfig.compile = (d.compile && d.compile === true);
             defaultConfig.keeppath = (d.keeppath && d.keeppath === true);
+            defaultConfig.fastupload = (d.fastupload && d.fastupload === true);
             _logger.log('Project based configuration loaded');
         }
     }catch (err){
@@ -181,6 +182,9 @@ _cli
 
     // sets the remote filename
     .option('-n, --remotename <remotename>', 'Set destination file name. Default is same as original. Only available when uploading a single file!', false)
+
+    // use fast upload
+    .option('-f, --fastupload', 'Boost the upload speed by using base64 encoding. IMPORTANT: The NodeMCU module "encode" must be present on the firmeware (which is not the case by default)!', false)
 
     .action(function(localFiles, opt){
         var options = cliPrepare(opt);

--- a/bin/nodemcu-tool.js
+++ b/bin/nodemcu-tool.js
@@ -184,7 +184,7 @@ _cli
     .option('-n, --remotename <remotename>', 'Set destination file name. Default is same as original. Only available when uploading a single file!', false)
 
     // use fast upload
-    .option('-f, --fastupload', 'Boost the upload speed by using base64 encoding. IMPORTANT: The NodeMCU module "encode" must be present on the firmeware (which is not the case by default)!', false)
+    .option('-f, --fastupload', 'Boost the upload speed by using base64 encoding. IMPORTANT: The NodeMCU module "encode" must be present on the firmware (which is not the case by default)!', false)
 
     .action(function(localFiles, opt){
         var options = cliPrepare(opt);

--- a/bin/nodemcu-tool.js
+++ b/bin/nodemcu-tool.js
@@ -76,7 +76,8 @@ function cliPrepare(options){
         all:        options.all         || false,
         json:       options.json        || false,
         raw:        options.raw         || false,
-        softreset:  options.softreset   || false
+        softreset:  options.softreset   || false,
+        fastupload: options.fastupload    || false
     };
 
     // project based configuration

--- a/lib/LuaCommandBuilder.js
+++ b/lib/LuaCommandBuilder.js
@@ -39,6 +39,9 @@ var lua_commands = {
     // helper function to write hex encoded content to file
     hexWriteHelper: "function __hexwrite(s) for c in s:gmatch('..') do file.write(string.char(tonumber(c, 16))) end end",
 
+    // helper function to write base64 encoded content to file. The module "encoder" must be available in the NodeMCU Firmeware.
+    base64WriteHelper: "function __hexwrite(s) file.write(encoder.fromBase64(s)) end",
+
     // helper function to read file as hex and write content to uart
     hexReadHelper: "function __hexread() while true do c = file.read(1) if c == nil then print('') break end uart.write(0, string.format('%02X', string.byte(c))) end end"
 };

--- a/lib/NodeMcuConnector.js
+++ b/lib/NodeMcuConnector.js
@@ -16,7 +16,7 @@ function NodeMcuConnector(devicename, baudrate){
     this.isConnected = false;
     this.name = devicename;
     this.baudrate = baudrate;
-    this.isHexWriteHelperUploaded = false;
+    this.isWriteHelperUploaded = false;
 
     // handle low level errors
     this.device.onError(function(err){
@@ -212,7 +212,7 @@ NodeMcuConnector.prototype.upload = function(localName, remoteName, options, com
     }
 
     // convert buffer to hex
-    var content = rawContent.toString('hex');
+    var content = options.fastupload ? rawContent.toString('base64') : rawContent.toString('hex');
 
     // get absolute filesize
     var absoluteFilesize = rawContent.length;
@@ -278,14 +278,15 @@ NodeMcuConnector.prototype.upload = function(localName, remoteName, options, com
 
 
     // hex write helper already uploaded within current session ?
-    if (this.isHexWriteHelperUploaded){
+    if (this.isWriteHelperUploaded){
         // start transfer directly
         startTransfer();
 
     // otherwise upload helper
     }else{
         // transfer helper function to decode hex data
-        this.device.executeCommand(_luaCommandBuilder.command.hexWriteHelper, function(err, echo, response) {
+        var command = options.fastupload ? _luaCommandBuilder.command.base64WriteHelper : _luaCommandBuilder.command.hexWriteHelper;
+        this.device.executeCommand(, function(err, echo, response) {
             // successful opened ?
             if (err) {
                 completeCb('Cannot transfer hex.decode helper function - ' + err);
@@ -293,7 +294,7 @@ NodeMcuConnector.prototype.upload = function(localName, remoteName, options, com
             }
 
             // set flag
-            this.isHexWriteHelperUploaded = true;
+            this.isWriteHelperUploaded = true;
 
             // start file transfer on upload complete
             startTransfer();

--- a/lib/NodeMcuConnector.js
+++ b/lib/NodeMcuConnector.js
@@ -241,7 +241,7 @@ NodeMcuConnector.prototype.upload = function(localName, remoteName, options, com
                     var l = chunks.shift();
 
                     // increment size counter
-                    currentUploadSize += l.length/2 ;
+                    currentUploadSize += (options.fastupload ? l.length : l.length/2);
 
                     // write first element to file
                     this.device.executeCommand('__hexwrite("' + l + '")', function(err, echo, response){
@@ -286,7 +286,7 @@ NodeMcuConnector.prototype.upload = function(localName, remoteName, options, com
     }else{
         // transfer helper function to decode hex data
         var command = options.fastupload ? _luaCommandBuilder.command.base64WriteHelper : _luaCommandBuilder.command.hexWriteHelper;
-        this.device.executeCommand(, function(err, echo, response) {
+        this.device.executeCommand(command, function(err, echo, response) {
             // successful opened ?
             if (err) {
                 completeCb('Cannot transfer hex.decode helper function - ' + err);


### PR DESCRIPTION
I use base64 encoding for uploading files. Then the NodeMCU "encode" module is used for decoding, which is really more efficient.
As the NodeMCU "encode" module is not included by default on the firmware, I have add this as an option, so that the user can choose whether use it or not.