### PR TITLE
Fixed issue #36 (Uploading empty files)

### DIFF
--- a/lib/NodeMcuConnector.js
+++ b/lib/NodeMcuConnector.js
@@ -221,7 +221,7 @@ NodeMcuConnector.prototype.upload = function(localName, remoteName, options, com
         var absoluteFilesize = content.length;
 
         // split file content into chunks
-        var chunks = content.match(/.{1,232}/g);
+        var chunks = content.match(/.{1,232}/g) || [];
 
         // open remote file for write
         this.device.executeCommand(_luaCommandBuilder.prepare('fileOpen', [remoteName, 'w+']), function(err, echo, response){
@@ -271,8 +271,24 @@ NodeMcuConnector.prototype.upload = function(localName, remoteName, options, com
 
             }.bind(this);
 
-            // start transfer
-            writeChunk();
+            var createFile = function(fileCreatedCb) {
+                // make sure we do at least one (empty) write to create the file
+                this.device.executeCommand('__nmtwrite("")', function(err, echo, response){
+                    if (err){
+                        completeCb('Cannot write to remote file - ' + err, null);
+                        return;
+                    }
+
+                   // run progress callback
+                   progressCb.apply(progressCb, [currentUploadSize, absoluteFilesize]);
+                   fileCreatedCb();
+                })
+            }.bind(this);
+            
+            createFile(function() {   
+                // start transfer   
+                writeChunk();
+            });
 
         }.bind(this));
     }.bind(this);

--- a/lib/NodeMcuConnector.js
+++ b/lib/NodeMcuConnector.js
@@ -258,6 +258,9 @@ NodeMcuConnector.prototype.upload = function(localName, remoteName, options, com
                         writeChunk();
                     });
                 }else{
+                    // ensure that the progress callback is called, even for empty files  
+                    progressCb.apply(progressCb, [currentUploadSize, absoluteFilesize]);
+
                     // send file close command
                     this.device.executeCommand(_luaCommandBuilder.command.fileCloseFlush, function(err, echo, response){
                         if (err){
@@ -271,24 +274,8 @@ NodeMcuConnector.prototype.upload = function(localName, remoteName, options, com
 
             }.bind(this);
 
-            var createFile = function(fileCreatedCb) {
-                // make sure we do at least one (empty) write to create the file
-                this.device.executeCommand('__nmtwrite("")', function(err, echo, response){
-                    if (err){
-                        completeCb('Cannot write to remote file - ' + err, null);
-                        return;
-                    }
-
-                   // run progress callback
-                   progressCb.apply(progressCb, [currentUploadSize, absoluteFilesize]);
-                   fileCreatedCb();
-                })
-            }.bind(this);
-            
-            createFile(function() {   
-                // start transfer   
-                writeChunk();
-            });
+            // start transfer
+            writeChunk();
 
         }.bind(this));
     }.bind(this);


### PR DESCRIPTION
I fixed the issue by doing an initial empty write. This ensures that the file will be created even if it's empty. 
I also made sure that `chunks` will have a length property by making it an empty array if the file is empty.