### PR TITLE
preliminary support for ESP32 (e.g. LOLIN32 Lite)

### DIFF
--- a/lib/LuaCommandBuilder.js
+++ b/lib/LuaCommandBuilder.js
@@ -6,6 +6,9 @@ var lua_commands = {
     // info command (flash id)
     nodeInfo: 'print(node.info());',
 
+    // chipid info
+    chipid: 'print(node.chipid());',
+
     // file system info
     fsInfo: 'print(file.fsinfo())',
 

--- a/lib/NodeMcuConnector.js
+++ b/lib/NodeMcuConnector.js
@@ -64,7 +64,7 @@ NodeMcuConnector.prototype.connect = function(cb, applyConnectionCheck, connectD
                                 cb(error, null);
                             }else{
                                 // show nodemcu device info
-                                cb(null, 'Version: ' + data.version + ' | ChipID: 0x' + data.chipID + ' | FlashID: 0x' + data.flashID);
+                                cb(null, 'Arch: ' + data.arch + ' | Version: ' + data.version + ' | ChipID: 0x' + data.chipID + ' | FlashID: 0x' + data.flashID);
                             }
                         });
                     }
@@ -162,6 +162,7 @@ NodeMcuConnector.prototype.checkConnection = function(cb){
 
 // fetch nodemcu device info
 NodeMcuConnector.prototype.fetchDeviceInfo = function(cb){
+    var me = this;
     // run the node.info() command
     this.device.executeCommand(_luaCommandBuilder.command.nodeInfo, function(err, echo, data){
         if (err){
@@ -169,13 +170,25 @@ NodeMcuConnector.prototype.fetchDeviceInfo = function(cb){
         }else {
             // replace whitespaces with single delimiter
             var p = data.replace(/\s+/gi, '-').split('-');
-
             if (p.length != 8) {
-                cb('Invalid node.info() Response: ' + data, null);
+                // let's try to probe the chipid, as dev-esp32 nodemcu lacks node.info() as of 2018/01 (might change later)
+                me.device.executeCommand(_luaCommandBuilder.command.chipid, function(err, echo, data){
+                   if (err) {
+                       cb('Invalid node.chipid() Response: ' + data, null);
+                   } else {
+                       var m = data.match(/^0x(\w+)/);     // esp32 chipid (hex with '0x' prefix)?
+                       if(m) {
+                           cb(null, { chipID: m[1], flashID: '????????', arch: 'esp32', version: '?????' });
+                       } else {
+                           cb('Invalid node.chipid() Response: ' + data, null);
+                       }
+                   }
+                });
             } else {
                 // process data
                 cb(null, {
                     version: p[0] + '.' + p[1] + '.' + p[2],
+                    arch: 'esp8266',
                     chipID: parseInt(p[3]).toString(16),
                     flashID: parseInt(p[4]).toString(16),
                     flashsize: p[5] + 'kB',


### PR DESCRIPTION
NodeMCU for ESP32 (dev-esp32) lacks `node.info()` which is used to determine NodeMCU firmware on the ESP device, this patch stills keeps probing `node.info()`, if it fails it tries to probe `node.chipid()` and if the response is hex with prefix '0x' then it's very likely an ESP32, and then I set the data as far I know (no flashID or flashsize etc). 

Result is, `nodemcu-tool` recognizes the ESP32 device and `upload` works. I added a new field 'arch' which contains 'esp8266' or 'esp32'. 