### PR TITLE
Invalid module entry file

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "LICENSE.md",
         "README.md"
     ],
-    "main": "./lib/nodemcu-tool.js",
+    "main": "./lib/nodemcu-connector.js",
     "bin": {
         "nodemcu-tool": "bin/nodemcu-tool.js"
     },


### PR DESCRIPTION
fixed: fix the main filed so that the program can get the correct entry via require('nodemcu-tool')

Hi, thanks you for providing such a useful and free tool. I am using your tool to develop a software and are also ready to offer it to the community for free.

But during the period I encountered some problems and spent a little time to solve the problem, Finally, I found that the main field in the package is wrong. I don't know why you want to set the value of this field to this, or you may have accidentally made a mistake.

Finally, I modified this value and it works fine in my program.