### PR TITLE
added another vendor id - LoLin V3

### DIFF
--- a/lib/connector/list-devices.js
+++ b/lib/connector/list-devices.js
@@ -6,7 +6,10 @@ const knownVendorIDs = [
     '1a86',
 
     // NodeMCU v1.1 - CP2102 Adapter | 0x10c4  Cygnal Integrated Products, Inc
-    '10c4'
+    '10c4',
+
+    // NodeMCU v3 - CH340G Adapter | 0x1A86 Nanjing QinHeng Electronics Co., Ltd.
+    '1A86'
 ];
 
 // show connected serial devices


### PR DESCRIPTION
There is a NodeMCU created by wch.cn, USB\VID_1A86&PID_7523\7&1CA76CA2&0&3 that has a slightly different vendor id. The tool was not detecting it. 