### PR TITLE
fix: The includes() method is case sensitive.

### DIFF
--- a/lib/connector/list-devices.js
+++ b/lib/connector/list-devices.js
@@ -3,10 +3,10 @@ const _serialport = require('../transport/serialport');
 // list of known vendor IDs
 const knownVendorIDs = [
     // NodeMCU v1.0 - CH341 Adapter | 0x1a86  QinHeng Electronics
-    '1a86',
+    '1A86',
 
     // NodeMCU v1.1 - CP2102 Adapter | 0x10c4  Cygnal Integrated Products, Inc
-    '10c4',
+    '10C4',
 
     // NodeMCU v3 - CH340G Adapter | 0x1A86 Nanjing QinHeng Electronics Co., Ltd.
     '1A86'
@@ -16,7 +16,6 @@ const knownVendorIDs = [
 async function listDevices(showAll){
     // get all available serial ports
     const ports = (await _serialport.list()) || [];
-
     // just pass-through
     if (showAll){
         return ports;
@@ -24,7 +23,8 @@ async function listDevices(showAll){
     // filter by vendorIDs
     }else{
         return ports.filter(function(item){
-            return knownVendorIDs.includes(item.vendorId);
+            // 
+            return knownVendorIDs.includes(item.vendorId && item.vendorId.toUpperCase());
         });
     }
 }


### PR DESCRIPTION
The includes() method is case sensitive. 

fix the `No Connected Devices found | Total: 0` when the letter mismatch

the effect 

![image](https://user-images.githubusercontent.com/4559753/57178435-6d5bc980-6ea2-11e9-9c5a-5927cf3bf3f0.png)
