### PR TITLE
Fix download command reliability

### DIFF
--- a/lib/connector/download.js
+++ b/lib/connector/download.js
@@ -41,7 +41,7 @@ async function download(remoteName){
 
     // close remote file for read
     try{
-        ({response} = await _virtualTerminal.executeCommand(_luaCommandBuilder.fileClose));
+        ({response} = await _virtualTerminal.executeCommand(_luaCommandBuilder.command.fileClose));
     }catch(e){
         _logger.debug(e);
         throw new Error('Cannot close remote file "' + remoteName + '"');


### PR DESCRIPTION
Manifests as every second download failing, caused by missing command object reference.