### PR TITLE
Add support for the dev-esp32-idf4 branch

### DIFF
--- a/lib/connector/check-connection.js
+++ b/lib/connector/check-connection.js
@@ -2,6 +2,8 @@ const _virtualTerminal = require('../transport/scriptable-serial-terminal');
 const _luaCommandBuilder = require('../lua/command-builder');
 const _logger = require('logging-facility').getLogger('connector');
 
+_luaCommandBuilder.command = _luaCommandBuilder.espCommands();
+
 // checks the node-mcu connection
 function checkConnection(){
 

--- a/lib/connector/connect.js
+++ b/lib/connector/connect.js
@@ -49,6 +49,9 @@ async function connect(devicename, baudrate, applyConnectionCheck=true, connectD
     // fetch device info
     const data = await _deviceInfo();
 
+    _luaCommandBuilder.setArch(data.arch);
+    _luaCommandBuilder.command = _luaCommandBuilder.espCommands();
+
     return 'Arch: ' + data.arch + ' | Version: ' + data.version + ' | ChipID: 0x' + data.chipID + ' | FlashID: 0x' + data.flashID;
 }
 

--- a/lib/connector/fsinfo.js
+++ b/lib/connector/fsinfo.js
@@ -29,7 +29,22 @@ async function fsinfo(){
     // files available (list not empty) ?
     if (response.length > 0){
         // split the file-list by ";"
-        const entries = response.trim().split(';');
+        let entries = response.trim().split(';');
+				
+				// Due to an error in the dev-esp32-idf4 branch - file.list() always returns filesize = 0
+				// we have to get the correct file size using getFileSize command
+				if (_luaCommandBuilder.getArch() === "esp32") {
+						const filesArray = [];
+						const filtered = entries.filter(f => f.includes(':'));
+					
+						for (const fnfs of filtered) {
+								const fileData = fnfs.split(':');
+								({response} = await _virtualTerminal.executeCommand(_luaCommandBuilder.prepare('getFileSize', [fileData[0]])));
+								fileData[1] = response
+								filesArray.push(fileData.join(':'));
+						}
+						entries = filesArray
+				}
 
         // process each entry
         entries.forEach(function(entry){

--- a/lib/connector/fsinfo.js
+++ b/lib/connector/fsinfo.js
@@ -29,22 +29,7 @@ async function fsinfo(){
     // files available (list not empty) ?
     if (response.length > 0){
         // split the file-list by ";"
-        let entries = response.trim().split(';');
-				
-				// Due to an error in the dev-esp32-idf4 branch - file.list() always returns filesize = 0
-				// we have to get the correct file size using getFileSize command
-				if (_luaCommandBuilder.getArch() === "esp32") {
-						const filesArray = [];
-						const filtered = entries.filter(f => f.includes(':'));
-					
-						for (const fnfs of filtered) {
-								const fileData = fnfs.split(':');
-								({response} = await _virtualTerminal.executeCommand(_luaCommandBuilder.prepare('getFileSize', [fileData[0]])));
-								fileData[1] = response
-								filesArray.push(fileData.join(':'));
-						}
-						entries = filesArray
-				}
+        const entries = response.trim().split(';');
 
         // process each entry
         entries.forEach(function(entry){

--- a/lib/connector/list-devices.js
+++ b/lib/connector/list-devices.js
@@ -9,7 +9,10 @@ const knownVendorIDs = [
     '10C4',
 
     // NodeMCU v3 - CH340G Adapter | 0x1A86 Nanjing QinHeng Electronics Co., Ltd.
-    '1A86'
+    '1A86',
+
+    // FTDI232 adapter | Product ID 6001
+    '0403',
 ];
 
 // show connected serial devices
@@ -23,7 +26,7 @@ async function listDevices(showAll){
     // filter by vendorIDs
     }else{
         return ports.filter(function(item){
-            // 
+            //
             return knownVendorIDs.includes(item.vendorId && item.vendorId.toUpperCase());
         });
     }

--- a/lib/lua/command-builder.js
+++ b/lib/lua/command-builder.js
@@ -37,6 +37,5 @@ function luaPrepare(commandName, args){
 module.exports = {
     espCommands: luaEspCommands,
     prepare: luaPrepare,
-    getArch: () => arch,
     setArch: (a) => {arch = a}
 };

--- a/lib/lua/command-builder.js
+++ b/lib/lua/command-builder.js
@@ -1,9 +1,21 @@
-const _esp8266_commands = require('./esp32-commands');
+const _esp32Commands = require('./esp32-commands');
+const _esp8266Commands = require('./esp8266-commands');
+
+let arch = null;
+
+// select a set of commands, depending on arch
+function luaEspCommands(){
+
+    return arch === "esp32" ? _esp32Commands : _esp8266Commands;
+}
 
 // prepare command be escaping args
 function luaPrepare(commandName, args){
+
+    const esp_commands = luaEspCommands();
+
     // get command by name
-    let command = _esp8266_commands[commandName] || null;
+    let command = esp_commands[commandName] || null;
 
     // valid command name provided ?
     if (command == null){
@@ -23,6 +35,8 @@ function luaPrepare(commandName, args){
 }
 
 module.exports = {
-    command: _esp8266_commands,
-    prepare: luaPrepare
+    espCommands: luaEspCommands,
+    prepare: luaPrepare,
+    getArch: () => arch,
+    setArch: (a) => {arch = a}
 };

--- a/lib/lua/command-builder.js
+++ b/lib/lua/command-builder.js
@@ -1,4 +1,4 @@
-const _esp8266_commands = require('./esp8266-commands');
+const _esp8266_commands = require('./esp32-commands');
 
 // prepare command be escaping args
 function luaPrepare(commandName, args){

--- a/lib/lua/esp32-commands.js
+++ b/lib/lua/esp32-commands.js
@@ -31,6 +31,10 @@ const lua_commands = {
     // list files on SPIFFS
     listFiles: 'local l = file.list();for k,v in pairs(l) do uart.write(0,k..":"..v..";") end print("")',
 
+    // get correct file size
+    getFileSize:
+    '__f=io.open("?") local s=__f:seek("end") __f:close() __f=nil print(s)',
+
     // file open
     fileOpen: '__f=io.open("?", "?") print(__f)',
 

--- a/lib/lua/esp32-commands.js
+++ b/lib/lua/esp32-commands.js
@@ -31,10 +31,6 @@ const lua_commands = {
     // list files on SPIFFS
     listFiles: 'local l = file.list();for k,v in pairs(l) do uart.write(0,k..":"..v..";") end print("")',
 
-    // get correct file size
-    getFileSize:
-    '__f=io.open("?") local s=__f:seek("end") __f:close() __f=nil print(s)',
-
     // file open
     fileOpen: '__f=io.open("?", "?") print(__f)',
 
@@ -58,4 +54,3 @@ const lua_commands = {
 };
 
 module.exports = lua_commands;
-

--- a/lib/lua/esp32-commands.js
+++ b/lib/lua/esp32-commands.js
@@ -1,0 +1,57 @@
+// lua command templates - central location for easier debugging
+const lua_commands = {
+    // connection info echo command,
+    echo: 'print("echo1337")',
+
+    // info command (flash id)
+    // v2 => v3 changed from list to table!
+    nodeInfoLegacy: 'print(node.info("hw"));',
+
+    // nodemcu >=3x info command
+    nodeInfo3: 'for k,v in pairs(node.info("?")) do print(k,v) end;',
+
+    // chipid info
+    chipid: 'print(node.chipid());',
+
+    // file system info
+    fsInfo: 'print(file.fsinfo())',
+
+    // format the file system
+    fsFormat: 'file.format()',
+
+    // compile a remote file
+    compile: 'node.compile("?")',
+
+    // run a file
+    run: 'dofile("?")',
+
+    // soft-reset
+    reset: 'node.restart()',
+
+    // list files on SPIFFS
+    listFiles: 'local l = file.list();for k,v in pairs(l) do uart.write(0,k..":"..v..";") end print("")',
+
+    // file open
+    fileOpen: '__f=io.open("?", "?") print(__f)',
+
+    // close a opened file
+    fileClose: '__f:close() __f=nil',
+
+    // remove file
+    fileRemove: 'file.remove("?")',
+
+    // file close & flush
+    fileCloseFlush: '__f:flush(f) __f:close() __f=nil',
+
+    // read file content
+    fileRead: '__nmtread()',
+
+    // helper function to write hex/base64 encoded content to file @see docs/TransferEncoding.md
+    transferWriteHelper: "if encoder and encoder.fromBase64 then _G.__nmtwrite = function(s) __f:write(encoder.fromBase64(s)) end print('b') else _G.__nmtwrite = function(s) for c in s:gmatch('..') do __f:write(string.char(tonumber(c, 16))) end end print('h') end",
+
+    // helper function to read hex/base64 encoded content from file  @see docs/TransferEncoding.md
+    transferReadHelper: "function __nmtread()local b = encoder and encoder.toBase64 while true do c = __f:read(b and 240 or 1) if c==nil then print('')break end uart.write(0, b and encoder.toBase64(c) or string.format('%02X', string.byte(c)))end print('') end"
+};
+
+module.exports = lua_commands;
+


### PR DESCRIPTION
NodeMCU in the latest dev-esp32-idf4 branch moved file IO from the file module to the standard Lua io.

See [Lua file functions moved to standard io module](https://github.com/AndiDittrich/NodeMCU-Tool/issues/89)

This PR adds support for the dev-esp32-idf4 branch. Depending on the type of ESP, the appropriate set of commands is automatically selected.

I have tested this feature in [the fork](https://github.com/serg3295/NodeMCU-Tool/tree/auto) with already applied PRs

[fix: upgrade prompt dep to fix non-existent property warning](https://github.com/AndiDittrich/NodeMCU-Tool/pull/92)

[Upgrade node-serialport dependency to v10 (Breaking Change)](https://github.com/AndiDittrich/NodeMCU-Tool/pull/93)
