### PR TITLE
Add support for esp32 'console' module

### DIFF
--- a/lib/connector/list-devices.js
+++ b/lib/connector/list-devices.js
@@ -13,6 +13,9 @@ const knownVendorIDs = [
 
     // FTDI232 adapter | Product ID 6001
     '0403',
+
+    // Espressif chips
+    "303A",
 ];
 
 // show connected serial devices

--- a/lib/lua/esp32-commands.js
+++ b/lib/lua/esp32-commands.js
@@ -37,7 +37,7 @@ const lua_commands = {
     listFiles: 'local l={}for k,v in pairs(file.list())do l[#l+1]=("%s:%d"):format(k,v)end;print(table.concat(l,";"))',
 
     // file open
-    fileOpen: '__f=io.open("?", "?") print(__f)',
+    fileOpen: 'local open=file.open or io.open;__f=open("?", "?") print(__f)',
 
     // close a opened file
     fileClose: '__f:close() __f=nil',

--- a/lib/lua/esp32-commands.js
+++ b/lib/lua/esp32-commands.js
@@ -34,7 +34,7 @@ const lua_commands = {
     reset: 'node.restart()',
 
     // list files on SPIFFS
-    listFiles: 'local l = file.list();for k,v in pairs(l) do uart.write(0,k..":"..v..";") end print("")',
+    listFiles: 'local l={}for k,v in pairs(file.list())do l[#l+1]=("%s:%d"):format(k,v)end;print(table.concat(l,";"))',
 
     // file open
     fileOpen: '__f=io.open("?", "?") print(__f)',
@@ -49,13 +49,13 @@ const lua_commands = {
     fileCloseFlush: '__f:flush(f) __f:close() __f=nil',
 
     // read file content
-    fileRead: '__nmtread()',
+    fileRead: "local b=encoder and encoder.toBase64 __nmtread(b)",
 
     // helper function to write hex/base64 encoded content to file @see docs/TransferEncoding.md
     transferWriteHelper: "if encoder and encoder.fromBase64 then _G.__nmtwrite = function(s) __f:write(encoder.fromBase64(s)) end print('b') else _G.__nmtwrite = function(s) for c in s:gmatch('..') do __f:write(string.char(tonumber(c, 16))) end end print('h') end",
 
     // helper function to read hex/base64 encoded content from file  @see docs/TransferEncoding.md
-    transferReadHelper: "function __nmtread()local b = encoder and encoder.toBase64 while true do c = __f:read(b and 240 or 1) if c==nil then print('')break end uart.write(0, b and encoder.toBase64(c) or string.format('%02X', string.byte(c)))end print('') end"
+    transferReadHelper: "function __nmtread(b)while true do c=__f:read(b and 240 or 1)if c==nil then print''break end;local d=b and encoder.toBase64(c)or string.format('%02X',string.byte(c))if console then console.write(d)else uart.write(0,d)end end print''end",
 };
 
 module.exports = lua_commands;


### PR DESCRIPTION
[PR #3666](https://github.com/nodemcu/nodemcu-firmware/pull/3666) on the `nodemcu-firmware/dev-esp32` branch moves the system console handling into its own module (console).
Now we have to use _console.write()_, _console.on()_ and _console.mode()_ instead of _uart.write()_, _uart.on()_ to interact with console.

This PR adds support for the new `console` module.

Additionally, _Espressif_ vendor ID has been added to the list of known vendor IDs.
VID 0x303a is used by ESP32-S2, ESP32-S3 and ESP32-C3 chips.

Added support for esp32 firmware compiled from the stale `dev-esp32-idf3-final` branch.
The dev-esp32-idf3-final branch firmware uses nodemcu `file` module instead of native Lua `io` module.
